### PR TITLE
Changed initial HTTP request to HEAD from GET

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -69,7 +69,7 @@ func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header
 	g.md5 = md5.New()
 
 	// use get instead of head for error messaging
-	resp, err := g.retryRequest("GET", g.url.String(), nil)
+	resp, err := g.retryRequest("HEAD", g.url.String(), nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The initial response only needs to get the content-length which will be returned by a HTTP HEAD request without any payload.  Eliminates extra network traffic and minimizes the number of HTTP GET requests on a resource (helps if there is throttling for GET but HEAD is allowed)